### PR TITLE
chore: use new abi version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/btcsuite/btcd v0.22.1
 	github.com/casbin/casbin/v2 v2.35.0
 	github.com/coreos/go-semver v0.3.0
-	github.com/darkobas2/go-storage-incentives-abi v0.5.1
+	github.com/darkobas2/go-storage-incentives-abi v0.5.2-0.20230615220143-06f544f7e971
 	github.com/darkobas2/go-sw3-abi v0.4.2
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/ethersphere/go-price-oracle-abi v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/darkobas2/go-storage-incentives-abi v0.5.1 h1:8nnRgjvgIivwbBGM9qEMFDsaCJQgb6m6dgqoxT41fIM=
-github.com/darkobas2/go-storage-incentives-abi v0.5.1/go.mod h1:IFAL8bModzA3attX5bp/zWiLThGblmsSNGrABbAiL6U=
+github.com/darkobas2/go-storage-incentives-abi v0.5.2-0.20230615220143-06f544f7e971 h1:wyoM+rhLS1JFWtk9HtA6DepvTPnDlc/fGkqI0QA/0Js=
+github.com/darkobas2/go-storage-incentives-abi v0.5.2-0.20230615220143-06f544f7e971/go.mod h1:IFAL8bModzA3attX5bp/zWiLThGblmsSNGrABbAiL6U=
 github.com/darkobas2/go-sw3-abi v0.4.2 h1:GcxweAmCiRWMIFMrM4p6PGCMBAD0DQ7gGrZvuXQnueo=
 github.com/darkobas2/go-sw3-abi v0.4.2/go.mod h1:wK/ZoZG2GCQTorepMvoKE/sQbFLJevUAjmV2btZeiFs=
 github.com/dave/jennifer v1.2.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=


### PR DESCRIPTION
Go is setting the version to v0.5.2-0.20230615220143-06f544f7e971 instead v0.5.1b as the tag is not exactly semver compatible.